### PR TITLE
Correção do caminho da pasta para execução correta dos testes com PyTest

### DIFF
--- a/.github/workflows/continuousintegration.yml
+++ b/.github/workflows/continuousintegration.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest test/teste.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+        pytest src/test/teste.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html


### PR DESCRIPTION
Correção do caminho da pasta 'Test' no script do fluxo de CI para a correta execução dos testes com PyTest.